### PR TITLE
integrate list of programs in europe

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -498,6 +498,13 @@
   urldate = {2023-07-20},
 }
 
+@Online{learnandteach,
+  author  = {{The teachingRSE project}},
+  title   = {Learning and teaching RSE},
+  url     = {https://de-rse.org/learn-and-teach/},
+  urldate = {2024-02-22},
+}
+
 @Article{Bird2016,
 	title = {Using Metadata Actively},
 	volume = {11},
@@ -5586,4 +5593,15 @@ doi = {10.1016/j.emj.2012.03.001},
   publisher = {{Zenodo}},
   urldate = {2023-06-07},
   keywords = {collaboration,community,data science,ethics,handbook,reproducibility,research practices}
+}
+
+@article{smith_SoftwareCitationPrinciples2016,
+  title = {Software Citation Principles},
+  author = {Smith, Arfon M. and Katz, Daniel S. and Niemeyer, Kyle E. and {FORCE11 Software Citation Working Group}},
+  year = {2016},
+  journal = {PeerJ Computer Science},
+  volume = {2},
+  number = {e86},
+  issn = {2376-5992},
+  doi = {10.7717/peerj-cs.86}
 }

--- a/paper.tex
+++ b/paper.tex
@@ -480,7 +480,8 @@ For RSEs this should be helped by to be formed academic facilities that enable t
 In the longer run, Research Software Engineering should be integrated into the existing study programmes.
 One option here would be the creation of an RSE master as a specialization for a computer science bachelor.
 This should be complemented by adding a minor in application-domain study programs such as biology, physics, engineering etc. to facilitate the communication between the corresponding two groups of RSEs.
-[\#SuccessStory: Msc “Scientific Computing” at TU Berlin, maybe use others from list as well https://www.tu.berlin/en/studying/study-programs/all-programs-offered/study-course/scientific-computing-m-sc/ ]
+There are already some master's programs available, (\eg in Berlin, Munich and Stuttgart) that develop this specialization on top of a domain bachelor.
+And of course there are data science curricula in the process of being created. A curated and continuously updated list of these programs is available at \cite{learnandteachlearn}.
 
 %\begin{thebibliography}{9}
 %\end{thebibliography}

--- a/positionpaper.bib
+++ b/positionpaper.bib
@@ -31,3 +31,10 @@
   doi          = {10.15497/rda00050},
   url          = {https://doi.org/10.15497/rda00050}
 }
+
+@Online{learnandteachlearn,
+  author  = {{The teachingRSE project}},
+  title   = {Learn research software engineering},
+  url     = {https://de-rse.org/learn-and-teach/learn},
+  urldate = {2024-02-24},
+}


### PR DESCRIPTION
This replaces the link to th eprogram at the TU Berlin, with our list of programs in Germany.