### PR TITLE
Add ref for data/software differences

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -5639,7 +5639,7 @@ doi = {10.1016/j.emj.2012.03.001},
 }
 
 @article{Lamprecht2020,
-  title = {Towards {FAIR} principles for\&nbsp;research\&nbsp;software},
+  title = {Towards {FAIR} principles for research software},
   volume = {3},
   issn = {2451-8484},
   url = {https://content.iospress.com/articles/data-science/ds190026},
@@ -5651,6 +5651,6 @@ doi = {10.1016/j.emj.2012.03.001},
   author = {Lamprecht, Anna-Lena and Garcia, Leyla and Kuzak, Mateusz and Martinez, Carlos and Arcila, Ricardo and Martin Del Pico, Eva and Dominguez Del Angel, Victoria and van de Sandt, Stephanie and Ison, Jon and Martinez, Paula Andrea and McQuilton, Peter and Valencia, Alfonso and Harrow, Jennifer and Psomopoulos, Fotis and Gelpi, Josep Ll and Chue Hong, Neil and Goble, Carole and Capella-Gutierrez, Salvador},
   month = jan,
   year = {2020},
-  note = {Publisher: IOS Press},
+  publisher = {IOS Press},
   pages = {37--59},
 }

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -5638,7 +5638,7 @@ doi = {10.1016/j.emj.2012.03.001},
   doi = {10.7717/peerj-cs.86}
 }
 
-@article{lamprecht_towards_2020,
+@article{Lamprecht2020,
   title = {Towards {FAIR} principles for\&nbsp;research\&nbsp;software},
   volume = {3},
   issn = {2451-8484},

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -5637,3 +5637,20 @@ doi = {10.1016/j.emj.2012.03.001},
   issn = {2376-5992},
   doi = {10.7717/peerj-cs.86}
 }
+
+@article{lamprecht_towards_2020,
+  title = {Towards {FAIR} principles for\&nbsp;research\&nbsp;software},
+  volume = {3},
+  issn = {2451-8484},
+  url = {https://content.iospress.com/articles/data-science/ds190026},
+  doi = {10.3233/DS-190026},
+  language = {en},
+  number = {1},
+  urldate = {2024-03-06},
+  journal = {Data Science},
+  author = {Lamprecht, Anna-Lena and Garcia, Leyla and Kuzak, Mateusz and Martinez, Carlos and Arcila, Ricardo and Martin Del Pico, Eva and Dominguez Del Angel, Victoria and van de Sandt, Stephanie and Ison, Jon and Martinez, Paula Andrea and McQuilton, Peter and Valencia, Alfonso and Harrow, Jennifer and Psomopoulos, Fotis and Gelpi, Josep Ll and Chue Hong, Neil and Goble, Carole and Capella-Gutierrez, Salvador},
+  month = jan,
+  year = {2020},
+  note = {Publisher: IOS Press},
+  pages = {37--59},
+}

--- a/paper.tex
+++ b/paper.tex
@@ -26,6 +26,8 @@
     Alexander Struck
     \and
     Axel Loewe
+    \and
+    Markus Ankenbrand
 }
 
 \date{\today}

--- a/paper.tex
+++ b/paper.tex
@@ -82,7 +82,7 @@ Several stakeholder perspectives are discussed and supported by (inter)national 
 Research Data Management has proved to benefit data quality through training researchers, the reusability through data repositories and to avoid duplication of effort.
 [TODO elaborate parallels to RDM SuccessStory] For over a decade, research funders and organizations made a significant effort to establish RDM and teams around it.
 We assume that research software will follow a similar trajectory.
-\footnote{For arguments why research software is unlike data, see REF .}
+\footnote{For arguments why research software is unlike data, see \autocite{Lamprecht2020}.}
 While we focus on Germany here, it is beneficial to review how other countries approach research software.
 In the UK, for example, many universities started initiating dedicated RSE departments about a decade ago~\autocite{Crouch2013}.
 The successful establishment of such staff roles is a role model for similar academic organizations worldwide.


### PR DESCRIPTION
One full section of the Lamprecht et al. 2020 paper "Towards FAIR principles for research software" is "2. Software is not data" where the differences between data and software are elaborated on.

- **Add Lamprecht et al. 2020**
- **Add reference to Lamprecht paper**

Related #21
