### PR TITLE
Homogenization of IT department and computing center

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -358,10 +358,10 @@ The question whether RSE and RDM should be located in two separate groups or sho
 \subsection{Module 6: RSE Infrastructure Provisioning}
 \label{sec:infrastructure}
 
-Although IT infrastructure provisioning is usually the purview of an institution's IT department and/or the computing center,
-a central RSE department can provide extra services by acting as an intermediary for RSE infrastructure and by hosting pilot instances of new tools and services.
+IT and (potentially high-performance) computing infrastructure provisioning is usually the purview of an institution's IT department and/or a computing center.
+However, a central RSE department can provide extra services by acting as an intermediary for RSE infrastructure and by hosting pilot instances of new tools and services.
 IT departments typically only provide the service for hosting and accessing IT infrastructures, such as RSE infrastructures.
-Central RSE departments are a link between the central services offered either by IT departments or over-archlingly available services on one side,
+Central RSE departments are a link between the central services offered either by IT departments, computing centers or over-archlingly available services on one side,
 and decentralized RSEs on the other, offering documentation, training and best-practices to efficiently and effectively use available services and comply with established processes.
 
 Furthermore, the central RSE department can offer consulting for decentralized RSEs to guide selection processes of the tools and services best suited for each project.
@@ -372,8 +372,9 @@ This evaluation will specifically consider a wider applicability of the tool, wi
 
 It is crucial that the RSE department does not compete with the IT department, nor should it duplicate existing infrastructure.
 On the contrary, the RSE department should act as a multiplier for the RSE-relevant services offered by the IT department, helping RSEs to discover and use existing and upcoming services.
-Once the bilateral collaboration between RSE and IT departments has been established, a stricter policy-based involvement of the RSE department for infrastructure requests is envisioned.
-Overall, by acting as an intermediary for RSE infrastructure related requests, the central RSE department can relieve the IT department and provide decentralized RSEs with the specific support they require.
+Similarly, the RSE department can promote the use of the available computing infrastructure provided by a computing center, helping with the support of the users when RSE-related questions in this context arise.
+Once the mutual collaboration between RSE department, IT department and computing center has been established, a stricter policy-based involvement of the RSE department for infrastructure requests is envisioned.
+Overall, by acting as an intermediary for RSE infrastructure related requests, the central RSE department can augment the IT department and the computing center, providing decentralized RSEs with the specific support they require.
 
 \subsection{Module 7: Research Software Engineering Research}
 \label{sec:rseresearch}
@@ -526,7 +527,7 @@ Such a concept should specify the idea of the department, its responsibilities a
 
 A rather difficult and crucial question can be the localization of the department within the organizational structure of the institution.
 A canonical place would be a new subunit of an institutional body close to software,
-training services and computing such as the institution's IT department or library.
+training services and computing such as the institution's IT department, the computing center or the library.
 Since most institutions already have an RDM department, it seems natural to add the RSE department as a parallel structure.
 Another choice for the superordinate body, particularly at universities, is the faculty for computer science.
 Determining the best place may involve discussing with several stakeholders at the institution and can already be beneficial for creating a


### PR DESCRIPTION
This addresses #63, adding the computing center's view where necessary/reasonable. Note, this does not cover #62 and still uses the term "RSE department" to keep those two changes separate.