### PR TITLE
Cite RSE organisations and funding opportunities

### DIFF
--- a/.github/workflows/paper.yml
+++ b/.github/workflows/paper.yml
@@ -37,6 +37,7 @@ jobs:
           name: PDF files
           path: ./github_artifacts
   deploy:
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'DE-RSE/2023_paper-RSE-groups' }}
     needs: [build]
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -519,9 +519,14 @@
 
 @inproceedings{Blech2022,
 	author = {Blech, Christopher and Dreyer, Nils and Friebel, Bj{\"o}rn and R. Jacob, Christoph and Shamil Jassim, Mostafa and Jehl, Leander and Kapitza, R{\"u}diger and Krafczyk, Manfred and K{\"u}rner, Thomas and C. Langer, Sabine and Linxweiler, Jan and Mahhouk, Mohammad and Marcus, Sven and Messadi, Ines and Peters, S{\"o}ren and Pilawa, Jan-Marc and K. Sreekumar, Harikrishnan and Str{\"o}tgen, Robert and Stump, Katrin and Vogel, Arne and Wolter, Mario},
-	booktitle = {campusSOURCE Award 2022},
-	title = {{SURESOFT}: {Towards} {Sustainable} {Research} {Software}},
+	booktitle = {{campusSOURCE} Award 2022},
+	title = {{SURESOFT}: Towards Sustainable Research Software},
 	year = {2022},
+	month = jul,
+	eventdate = {2022-03-17},
+	eventitle = {CampusSource Conference},
+	venue = {FernUniversität in Hagen},
+	doi = {10.24355/dbbs.084-202210121528-0},
 }
 
 
@@ -2336,7 +2341,6 @@ urldate = {2023-06-16}
 	month = mar,
 	publisher = {Zenodo},
 	title = {UK Research Software Survey 2014},
-	url = {https://doi.org/10.5281/zenodo.14809},
 	year = 2015,
 }
 
@@ -5639,4 +5643,103 @@ doi = {10.1016/j.emj.2012.03.001},
   number = {e86},
   issn = {2376-5992},
   doi = {10.7717/peerj-cs.86}
+}
+
+@Article{goth_foundational_competencies_2024,
+  title={Foundational Competencies and Responsibilities of a Research Software Engineer},
+  author={Goth, Florian and Alves, Renato and Braun, Matthias and Castro, Leyla Jael and Chourdakis, Gerasimos and Christ, Simon and Cohen, Jeremy and Druskat, Stephan and Erxleben, Fredo and Grad, Jean-No{\"e}l and Hagdorn, Magnus and Hodges, Toby and Juckeland, Guido and Kempf, Dominic and Lamprecht, Anna-Lena and Linxweiler, Jan and L{\"o}ffler, Frank and Martone, Michele and Schwarzmeier, Moritz and Seibold, Heidi and Thiele, Jan Philipp and von Waldow, Harald and Wittke, Samantha},
+  year={2024},
+  journal={arXiv},
+  volume={2311.11457},
+  doi={10.48550/arXiv.2311.11457},
+}
+
+@InProceedings{haupt_hifis_consulting_2021,
+  author       = {Haupt, Carina and Stoffers, Martin},
+  title        = {Roles in Research Software Engineering ({RSE}) Consultancies},
+  booktitle    = {Proceedings of the Research Software Engineers in {HPC} Workshop at {SC21} ({RSE-HPC-2021})},
+  booksubtitle = {Creating Community, Building Careers, Addressing Challenges},
+  year         = {2021},
+  month        = sep,
+  doi          = {10.5281/zenodo.5530444},
+  eventdate    = {2021-11-15},
+  venue        = {St. Louis, Missouri, USA},
+}
+
+@InProceedings{ulusoy_heidelberg_ssc_2024,
+  author       = {Ulusoy, Inga},
+  title        = {What institutions can do to provide support},
+  subtitle     = {The Scientific Software Center at {H}eidelberg University},
+  year         = {2024},
+  month        = jan,
+  doi          = {21.11116/0000-000E-5468-F},
+  eventtitle   = {Open Science Days},
+  eventdate    = {2024-01-29},
+  venue        = {Max Planck Digital Library, Berlin, Germany},
+}
+
+@Book{eurocc_success_stories_2023,
+  title     = {{EuroCC} Success Stories},
+  publisher = {HLRS},
+  year      = {2023},
+  editor    = {{Members of {EuroCC} Consortium}},
+  address   = {Stuttgart, Germany},
+  edition   = {1},
+  month     = may,
+  url       = {https://www.eurocc-access.eu/wp-content/uploads/2023/07/EuroCC_booklet_2023_final.pdf},
+}
+
+@Book{eurocc_success_stories_2024,
+  title     = {{EuroCC} Success Stories},
+  publisher = {HLRS},
+  year      = {2024},
+  editor    = {{Members of {EuroCC}~2 Consortium} and {{CASTIEL}~2 Consortium}},
+  address   = {Stuttgart, Germany},
+  edition   = {1},
+  month     = sep,
+  url       = {https://www.eurocc-access.eu/wp-content/uploads/2024/10/EuroCC2_Booklet2024_v1.0.pdf},
+}
+
+@Misc{katerbow_dfg_rse_2024,
+  author    = {Katerbow, Matthias and Mannseicher, Florian and Metzler, Saskia and Karcher, Stefan},
+  title     = {Handling of research software in the {DFG}'s funding activities},
+  year      = {2024},
+  month     = oct,
+  howpublished = {German Research Foundation},
+  address   = {Bonn, Germany},
+  doi       = {10.5281/zenodo.13919790},
+}
+
+@article{katerbow_dfg_rse_funding_2018,
+  author={Katerbow, Matthias and Royeck, Michael and Raabe, Andreas},
+  title={{DFG}-{F}{\"o}rderung und der digitale {W}andel in den {W}issenschaften},
+  subtitle={Ein {W}egweiser zu {F}{\"o}rderm{\"o}glichkeiten und {L}eitlinien},
+  journal={Informatik-Spektrum},
+  volume={41},
+  number={6},
+  pages={421--428},
+  year={2018},
+  publisher={Springer},
+  doi={10.1007/s00287-018-01135-0},
+}
+
+@Collection{moscho_inhouse_consulting_2010,
+editor={Moscho, Alexander and Richter, Ansgar},
+title={{I}nhouse-{C}onsulting in {D}eutschland: {M}arkt, {S}trukturen, {S}trategien},
+year={2010},
+publisher={Gabler},
+address={Wiesbaden},
+isbn={978-3-8349-8572-9},
+doi={10.1007/978-3-8349-8572-9},
+}
+
+@article{wright_ambivalent_internal_consultant_2009,
+author = {Wright, Christopher},
+title = {Inside Out? Organizational Membership, Ambiguity and the Ambivalent Identity of the Internal Consultant},
+year = {2009},
+journal = {British Journal of Management},
+volume = {20},
+number = {3},
+pages = {309--322},
+doi = {10.1111/j.1467-8551.2008.00585.x},
 }

--- a/contributors.yml
+++ b/contributors.yml
@@ -1,13 +1,19 @@
 authors:
-  - author: "Markus Ankenbrand"
+  - author: "Markus J. Ankenbrand"
     firtname: Markus J.
     lastName: Ankenbrandt
     initials: MJA
-    affilications: Center for Computational and Theoretical Biology, University of Würzburg, Germany
-      -
+    affiliations:
+      - Center for Computational and Theoretical Biology, University of Würzburg, Germany
     orcid: 0000-0002-6620-807X
 
   - author: "Bernd Flemisch"
+    firstName: Bernd
+    lastName: Flemisch
+    initials: BF
+    affiliations:
+      - Institute for Modelling Hydraulic and Environmental Systems, University of Stuttgart, Germany
+    orcid: 0000-0001-8188-620X
 
   - author: "Florian Goth"
     firstName: Florian
@@ -20,7 +26,7 @@ authors:
     acknowledgements: |
       FG acknowledges funding from the Deutsche Forschungsgemeinschaft
       (DFG, German Research Foundation) through the SFB 1170 “Tocotronics”,
-      project Z03 - project number \geprislink{258499086}.
+      project Z03 - project number \href{https://gepris.dfg.de/gepris/projekt/258499086?language=en}{258499086}.
 
   - author: "Jean-Noël Grad"
     firstName: Jean-Noël
@@ -32,11 +38,14 @@ authors:
     email: jgrad@icp.uni-stuttgart.de
     acknowledgements: |
       JNG acknowledges funding from the Deutsche Forschungsgemeinschaft
-      (DFG, German Research Foundation) - project number \geprislink{391126171}
-      (PI: Holm) and from the European Union – this work has received funding
+      (DFG, German Research Foundation) - project number \href{https://gepris.dfg.de/gepris/projekt/391126171?language=en}{391126171}
+      (PI: Holm), from the German Federal Ministry of Education and Research
+      (Bundesministeriums für Bildung und Forschung, BMBF) under the funding
+      code \href{https://www.kooperation-international.de/foerderung/projekte/detail/info/verbundprojekt-multixscale-hpc-exzellenzzentrum-fuer-multi-skalen-simulationen-auf-hoechstleitungsrechnern-1}{16HPC095},
+      and from the European Union – this work has received funding
       from the European High Performance Computing Joint Undertaking (JU) and
       countries participating in the project under grant agreement
-      No [101093169](https://doi.org/10.3030/101093169).
+      No \href{https://doi.org/10.3030/101093169}{101093169}.
 
   - author: "Dominic Kempf"
     firstName: Dominic

--- a/paper.tex
+++ b/paper.tex
@@ -74,8 +74,7 @@ They are highly skilled team members who may also choose to conduct their own re
 However, we also recognise RSEs who have chosen to focus on a technical role as an alternative to a traditional research role.\\
 \textbf{Researchers:}\\
 RSEs might also be researchers.
-However, for the lack of a proper term and to avoid many “non-RSE researchers” within the text, we will refer by “researchers” to all non-RSEs involved in research or in research supporting organisations such as in \eg{} libraries, hence those that are at most sporadically performing RSE actions.
-
+However, for the lack of a proper term and to avoid many “non-RSE researchers” within the text, we will refer by “researchers” to all non-RSEs involved in research or in research supporting organisations such as in \eg{} libraries, hence those that are at most sporadically performing RSE actions.\\
 \textbf{RSE Hub}:\\
 This is our general term for the central RSE team throughout this paper.
 These RSE Hubs can take the form of, e.g., full RSE units, smaller RSE groups, Open Source Program Office (OSPOs), virtually across multiple units or combined under single leadership,
@@ -89,7 +88,7 @@ All of these implementations are considered, taking into account the large varie
 
 The quote above is the shortes possible summary of this chapter: most if not all motivation to provide RSE services stems from improving research.
 Tasks RSEs perform include training, e.g.\ to improve the often low-quality code developed by beginners~\autocite{Ostlund2023}, consultation services, e.g.\ regarding frameworks or algorithm selection, licensing.
-For an overview of typical tasks of RSEs and the competencies required, see~\autocite{competencies-paper}, especially section\ 4.4:\ “RSE tasks and responsibilities”.
+For an overview of typical tasks of RSEs and the competencies required, see~\autocite{goth_foundational_competencies_2024}, especially section\ 4.4:\ “RSE tasks and responsibilities”.
 
 \subsection{Pooling: a necessary ingredient}
 As undoubtedly beneficial RSEs are for research, the main focus of the present paper lies on central RSE teams.
@@ -98,6 +97,7 @@ There are at least three pooling dimensions for research instititions to benefit
 The first, pooling of \textbf{funding}, allows organisations to invest in human resources through long-term expert RSEs.
 A central RSE team on long-term contracts will act as a knowledge hub due to their experience in and support of several disciplines as well as established contacts within the organisation.
 This is comparable to commercial/industry R\&D departments, where key software architects and developers establish a knowledge hub and consult with as many projects as necessary [REF].
+% side-note: it's also similar to “inhouse consulting” in management\autocite{moscho_inhouse_consulting_2010}. They even formed a national network to raise awareness about the internal consultant role (https://inhouse-consulting.de/).
 Subject matter experts like software architects, database administrators and other tooling specialists are organized centrally and share their knowledge by consulting with decentralized projects.
 It makes economically sense to organise such personel as cost-effective as possible since not every project can afford or needs such RSE FTEs.
 Most academic research organisations have established centralized tooling, e.g.\ storage or High-Performance-Computing\ (HPC), but only a few consider software development and consultancy a relevant service yet.
@@ -112,7 +112,7 @@ Their diversity in skills (languages, frameworks, front/back-end, UX, management
 This will save money otherwise spent in duplication of efforts.
 It might mean that a central RSE unit has a portfolio that is too broad for most individual research groups, but it also means that involving RSEs from these central groups automatically brings in new ideas and becomes a catalyst for interdisciplinary collaboration within the organisation.
 
-The third kind of pooling is visible most of all of all from a users perspective: a \textbf{single, central contact point} for digital challences is invaluable to researchers, who's first problem often is to not know whom to contact, partially because while they know what they want, they might not know what they need.
+The third kind of pooling is visible most of all of all from a users perspective: a \textbf{single, central contact point} for digital challenges is invaluable to researchers, whose first problem often is to not know whom to contact, partially because while they know what they want, they might not know what they need.
 A central RSE team can, due to its proximity to research, much better listen to the wishes expressed by researchers and then help formulate needs and act as a channel to either reformulate and redirect the request or also fulfill it in-house.
 The results are increased research speed and quality and with that a higher reputation of the entire research organisation.
 
@@ -145,8 +145,8 @@ Due to the similar nature of both, data and software, and their importance in to
 \subsubsection{Existing RSE efforts}
 The concept of central RSE teams is also not untested.
 Examples of organisational RSE teams are for instance
- the Helmholtz HIFIS group\footnote{\url{https://events.hifis.net/category/4/}},
- the Scientific Software Center in Heidelberg\footnote{\url{https://www.ssc.uni-heidelberg.de/en}},
+ the Helmholtz HIFIS group\footnote{\url{https://events.hifis.net/category/4/}}\autocite{haupt_hifis_consulting_2021},
+ the Scientific Software Center in Heidelberg\footnote{\url{https://www.ssc.uni-heidelberg.de/en}}\autocite{ulusoy_heidelberg_ssc_2024},
  the Competence Center Digital Research (zedif) in Jena\footnote{\url{https://www.zedif.uni-jena.de/en/}},
  and the SURESOFT workshops series in Braunschweig\footnote{\url{https://suresoft.dev/}}~\autocite{Blech2022}.
 Another national pioneer is the Göttingen State and University Library.
@@ -166,8 +166,8 @@ While we focus on Germany here, it is beneficial to review how other countries a
 %Such code often requires long-term maintenance, support, new features or bug fixes.
 %The decision of curation is commonly based on measures that involve quality, academic or societal impact among many others.
 
-The Carpentries~\autocite{Carpentries} exemplify a similar success story [REF SuccessStory Carpentries https://carpentries.org/testimonials/].
-Requests or suggestions for even more training show the need for such services.
+The Carpentries\footnote{\url{https://carpentries.org}}\autocite{Wilson2006} exemplify a similar success story\footnote{Carpentries25 Testimonial Series: \url{https://carpentries.org/blog/tag/carpentries25/}}.
+Requests or suggestions for even more training show the need for such services\footnote{Carpentries Incubator and Carpentries Lab: \url{https://carpentries.org/lesson-development/community-lessons/}}.
 RSE services which benefit all disciplines/departments may represent a unique selling point for organisations competing for the brightest minds, see the examples from leading German universities above.
 
 %Given that RDM training or coordination is a centralized effort in most organisations, the time has come to implement a similar structure for research software services.
@@ -179,6 +179,8 @@ The successful establishment of such staff is a role model for similar academic 
 A range of already-existing RSE units can be seen in this map: \url{https://society-rse.org/community/rse-groups/}.
 In the UK, for example, almost all grant applications include software development in their budget.
 This allocated money can then be utilized to delegate/dispatch a central RSE person or group into a research project for a few weeks or months as necessary.
+
+National Competence Centres\footnote{EuroCC: \url{https://www.eurocc-access.eu/}} form a network of HPC-RSE consulting groups to share expertise with academic and industry actors\autocite{eurocc_success_stories_2023,eurocc_success_stories_2024}.
 
 \subsection{External expectations}
 
@@ -521,9 +523,10 @@ Nevertheless, convincing the institution to take the corresponding risk of faili
       This model has been successfully implemented at several UK universities.
       In order to scale, it needs to be supported by an institutional policy.
       Large scale collaborative projects can often apply for dedicated technical support positions that align well with the idea of RSE units.
+      For example, the German Research Foundation allows requesting funding for “central service units or external service providers” in grant proposals aimed at developing research software\autocite{katerbow_dfg_rse_2024}.
 \item Funding organisations are increasingly recognizing the need for sustainable research software
       development and are setting up correspondingly designated funding programmes.
-      The DFG has already organized three calls for proposals in 2016\footnote{\href{https://www.dfg.de/resource/blob/172674/1bcb181a6451fdac9d94421776b52798/161026-dfg-ausschreibung-forschungssoftware-de-data.pdf}{Nachhaltigkeit von Forschungssoftware}}, 2019\footnote{\href{https://www.dfg.de/de/aktuelles/neuigkeiten-themen/info-wissenschaft/2019/info-wissenschaft-19-44}{Qualitätssicherung von Forschungssoftware durch ihre nachhaltige Nutzbarmachung}}, and 2022\footnote{\href{https://www.dfg.de/en/news/news-topics/announcements-proposals/2022/info-wissenschaft-22-85}{Research Software – Quality Assured and Re-usable}}.
+      The DFG has already organized three calls for proposals in 2016\footnote{\href{https://www.dfg.de/resource/blob/172674/1bcb181a6451fdac9d94421776b52798/161026-dfg-ausschreibung-forschungssoftware-de-data.pdf}{Nachhaltigkeit von Forschungssoftware}}, 2019\footnote{\href{https://www.dfg.de/de/aktuelles/neuigkeiten-themen/info-wissenschaft/2019/info-wissenschaft-19-44}{Qualitätssicherung von Forschungssoftware durch ihre nachhaltige Nutzbarmachung}}, and 2022\footnote{\href{https://www.dfg.de/en/news/news-topics/announcements-proposals/2022/info-wissenschaft-22-85}{Research Software – Quality Assured and Re-usable}}\autocite{katerbow_dfg_rse_funding_2018}.
       It is to be expected that even more programs will be launched in the future.
       An already established RSE concept at an institution increases the chances of being successful in such calls.
 \end{enumerate}
@@ -564,8 +567,8 @@ Such network-building has been successfully initiated and implemented at several
 Depending on local RSE efforts, teaching materials and associated training formats are likely to already exist,
 distributed over individual institutional groups.
 With the established network, the materials can be pooled and joint training can be offered to a wider institutional audience.
-This step can be facilitated and formalized by offering introductory courses with a recognized curriculum as provided by the carpentries\footnote{Examples \url{https://software-carpentry.org/lessons/}}
-or coderefinery\footnote{Examples \url{https://coderefinery.org/lessons/}}.
+This step can be facilitated and formalized by offering introductory courses with a recognized curriculum as provided by The Carpentries\footnote{Examples \url{https://software-carpentry.org/lessons/}}
+or CodeRefinery\footnote{Examples \url{https://coderefinery.org/lessons/}}.
 
 \subsubsection{Conceptualization}
 Decision makers at an institution usually require a concept upon which they will decide about the installation of an RSE unit.
@@ -649,6 +652,8 @@ This should be complemented by adding a minor in application-domain study progra
 There are already some master's programs available, (\eg{} in Berlin, Munich and Stuttgart) that develop this specialization on top of a domain bachelor.
 And of course there are data science curricula in the process of being created.
 A curated and continuously updated list of these programs is available at~\cite{learnandteachlearn}.
+
+% on the topic of acquiring and retaining staff, there's \autocite{VanTuyl2023} from US-RSE discussing career pathways, and \autocite{wright_ambivalent_internal_consultant_2009} about internal consultants and their struggle coming to terms with their work identity (in the management field)
 
 %\begin{thebibliography}{9}
 %\end{thebibliography}

--- a/positionpaper.bib
+++ b/positionpaper.bib
@@ -70,7 +70,6 @@ urldate = {2024-03-06},
   publisher    = {Zenodo},
   version      = {1.0},
   doi          = {10.15497/rda00050},
-  url          = {https://doi.org/10.15497/rda00050}
 }
 
 @Online{GitHubZenodo,
@@ -218,7 +217,7 @@ urldate = {2024-03-06},
 	journal = {Bausteine Forschungsdatenmanagement},
 	number = {1},
 	pages = {43-52},
-	title = {Forschungsdatenmanagement etablieren -- BestehendeService-Angebote und geplante Erweiterungen},
+	title = {{F}orschungsdatenmanagement etablieren -- {B}estehende {S}ervice-{A}ngebote und geplante {E}rweiterungen},
 	year = {2022},
 }
 
@@ -234,7 +233,6 @@ urldate = {2024-03-06},
 	pages = {142--142},
 	publisher = {Springer Science and Business Media LLC},
 	title = {Does your code stand up to scrutiny?},
-	url = {http://dx.doi.org/10.1038/d41586-018-02741-4},
 	volume = {555},
 	year = {2018},
 }
@@ -248,8 +246,7 @@ urldate = {2024-03-06},
 	keywords = {RSE, FAIR},
 	month = may,
 	publisher = {Zenodo},
-	title = {{FAIR Principles for Research Software (FAIR4RS Principles)}},
-	url = {https://doi.org/10.15497/RDA00068},
+	title = {{FAIR} Principles for Research Software ({FAIR4RS} Principles)},
 	version = {1.0},
 	year = {2022},
 }
@@ -257,11 +254,10 @@ urldate = {2024-03-06},
 
 @misc{Barker2024,
   doi = {10.5281/ZENODO.10816031},
-  url = {https://zenodo.org/doi/10.5281/zenodo.10816031},
   author = {Barker,  Michelle and Castro,  Leyla Jael and Fritzsch,  Bernadette and Katz,  Daniel S. and Martinez-Ortiz,  Carlos and Niehues,  Anna and Struck,  Alexander and Zhang,  Qian},
   keywords = {research software,  FAIR,  sustainability,  research},
   language = {en},
-  title = {The FAIR for Research Software Principles after two years: An adoption update},
+  title = {The {FAIR} for Research Software Principles after two years: An adoption update},
   publisher = {Zenodo},
   year = {2024},
   copyright = {Creative Commons Attribution 4.0 International}
@@ -279,9 +275,8 @@ urldate = {2024-03-06},
   series =       {SIGCSE 2023},
   publisher =    {Association for Computing Machinery},
   isbn =         9781450394314,
-  pages =        {792–798},
+  pages =        {792--798},
   doi =          {10.1145/3545945.3569829},
-  url =          {https://doi.org/10.1145/3545945.3569829}
 }
 
 


### PR DESCRIPTION
Description of changes:
- document DFG funding opportunities for RSEs (fixes #69)
- document HPC-RSE consulting network of NCCs
- add success stories from RSE departments and NCCs (partial fix for #16)
- update affiliations (fixes #71)
- cleanup BibTeX and footnotes