### PR TITLE
make compute centres and IT Departments to IT Units

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -386,7 +386,6 @@ Arguments and conclusions below have to be adapted to specific circumstances whe
 All research institutions in Germany do have a \textbf{central IT Unit} of one form or another.
 The central IT unit typically looks after central compute and storage infrastructure in data centres and associated network infrastructure.
 They also provide centralised software services such Email, web services, databases and administer standard desktops and laptops (at least for administrative staff).
-Normally, the assigned tasks of the IT unit are not research-driven but business oriented.
 However, research software often has to work within the environment provided by the central IT unit.
 A central RSE unit can help researchers adapt their software to run on central services where necessary.
 RSEs can also work with central IT staff to provide IT infrastructure well suited for research projects.

--- a/paper.tex
+++ b/paper.tex
@@ -404,7 +404,7 @@ Requests by researchers in that direction often touch both aspects, RSE and RDM\
 Thus, often a close collaboration between RSE and RDM groups helps everyone: both RSE and RDM groups by being able to offer a more comprehensive service than when working alone, as well as the researcher, who benefits from receiving this single coordinated service, instead of dealing with two independent entities.
 The question whether RSE and RDM should be located in two separate groups or should be combined in one common group is intentionally left open, as the answer depends on local, pre-existing circumstances.
 
-Some research institutions might host a dedicated \textbf{HPC group}, maybe even independent of the central IT unit.
+Some research institutions might host a dedicated \textbf{HPC group} which may or may not be part of the central IT unit.
 HPC is an RSE-related field, so HPC groups might already provide training, consulting and funding opportunities in this area.
 At the same time, HPC by nature focuses on highly efficient, many-core, if possible parallel computations.
 The challenges of an average researchers often start a long way before reaching that level, and they never might need to.

--- a/paper.tex
+++ b/paper.tex
@@ -384,12 +384,13 @@ However, note that as research organisations can differ widely from one another,
 Arguments and conclusions below have to be adapted to specific circumstances when applying them to specific environments.
 
 All research institutions in Germany do have a \textbf{central IT Unit} of one form or another.
-At the very least, these are the persons that deal with the every-day IT-need of the institution:
-Internet access, Email, Web, central administration of computers (at least that of administrative staff), etc.
-Typically, the assigned tasks of the IT unit are not research-driven, or also the staff does not have a research background.
+The central IT unit typically looks after central compute and storage infrastructure in data centres and associated network infrastructure.
+They also provide centralised software services such Email, web services, databases and administer standard desktops and laptops (at least for administrative staff).
+Normally, the assigned tasks of the IT unit are not research-driven but business oriented.
 However, research software often has to work within the environment provided by the central IT unit.
-A central RSE unit can help to either adapt the research software or even the environment such that the needs of researchers can be met.
-It is not unusual that this requires a level of engagement and understanding of the underlying research concepts that the staff of the IT unit cannot provide alone.
+A central RSE unit can help researchers adapt their software to run on central services where necessary.
+RSEs can also work with central IT staff to provide IT infrastructure well suited for research projects.
+Usually, this requires a level of engagement and understanding of both the underlying research concepts and IT infrastructure that the staff of the IT unit or the researchers cannot provide alone.
 
 A second important partner is the local \textbf{library}, which has already gained tasks much beyond the preservation and organisation of publications on physical paper for quite some time.
 Besides digital forms of rather traditional publications, these more and more include digital data and recently also software publications, their discovery and citation.

--- a/paper.tex
+++ b/paper.tex
@@ -422,10 +422,10 @@ Furthermore, the central RSE unit can offer consulting for RSEs in spokes to gui
 This holds for existing RSE, or more general IT, infrastructure.
 However, as scientists are working, by definition, at the cutting edge, they will often need or want to use the newest tools.
 When such a need is identified in the course of a consultation, a central RSE unit can set up and provide access to pilot instances to evaluate these tools.
-This evaluation will specifically consider a wider applicability of the tool, with the aim of handing over administration of widely required tools and services to, \eg{}, the central IT department.
+This evaluation will specifically consider a wider applicability of the tool, with the aim of handing over administration of widely required tools and services to, \eg{}, the central IT unit.
 
-It is crucial that the RSE unit does not compete with the IT department, nor should it duplicate existing infrastructure.
-On the contrary, the RSE unit should act as a multiplier for the RSE-relevant services offered by the IT department, helping RSEs to discover and use existing and upcoming services.
+It is crucial that the RSE unit does not compete with the IT unit, nor should it duplicate existing infrastructure.
+On the contrary, the RSE unit should act as a multiplier for the RSE-relevant services offered by the IT unit, helping RSEs to discover and use existing and upcoming services.
 Similarly, the RSE unit can promote the use of the available computing infrastructure provided by an IT unit, helping with the support of the users when RSE-related questions in this context arise.
 Once the mutual collaboration between an RSE unit and an IT unit has been established, a stricter policy-based involvement of the RSE unit for infrastructure requests is envisioned.
 Overall, by acting as an intermediary for RSE infrastructure related requests, the central RSE unit can augment the central IT unit, providing RSEs in spokes with the specific support they require.

--- a/paper.tex
+++ b/paper.tex
@@ -583,7 +583,7 @@ Such a concept should specify the idea of the RSE unit, its responsibilities and
 
 A rather difficult and crucial question can be the localisation of the RSE unit within the organisational structure of the institution.
 A canonical place would be a new subunit of an institutional body close to software,
-training services and computing such as the institution's IT unit, the IT unit or the library.
+training services and computing such as the local or central IT unit or the library.
 Since most institutions already have an RDM unit, it seems natural to add the RSE unit as a parallel structure.
 Another choice for the superordinate body, particularly at universities, is the faculty for computer science.
 Determining the best place may involve discussing with several stakeholders at the institution and can already be beneficial for creating a

--- a/paper.tex
+++ b/paper.tex
@@ -383,13 +383,13 @@ what usually their focus is and how we envision collaborations with an RSE unit.
 However, note that as research organisations can differ widely from one another, so can the tasks and even existence of the entities below.
 Arguments and conclusions below have to be adapted to specific circumstances when applying them to specific environments.
 
-All research institutions in Germany do have a \textbf{computing centre} of one form or another.
+All research institutions in Germany do have a \textbf{central IT Unit} of one form or another.
 At the very least, these are the persons that deal with the every-day IT-need of the institution:
 Internet access, Email, Web, central administration of computers (at least that of administrative staff), etc.
-Typically, the assigned tasks of the computing centre are not research-driven, or also the staff does not have a research background.
-However, research software often has to work within the environment provided by the computing centre.
+Typically, the assigned tasks of the IT Unit are not research-driven, or also the staff does not have a research background.
+However, research software often has to work within the environment provided by the central IT Unit.
 A central RSE unit can help to either adapt the research software or even the environment such that the needs of researchers can be met.
-It is not unusual that this requires a level of engagement and understanding of the underlying research concepts that the staff of the computing centre cannot provide alone.
+It is not unusual that this requires a level of engagement and understanding of the underlying research concepts that the staff of the IT Unit cannot provide alone.
 
 A second important partner is the local \textbf{library}, which has already gained tasks much beyond the preservation and organisation of publications on physical paper for quite some time.
 Besides digital forms of rather traditional publications, these more and more include digital data and recently also software publications, their discovery and citation.

--- a/paper.tex
+++ b/paper.tex
@@ -386,10 +386,10 @@ Arguments and conclusions below have to be adapted to specific circumstances whe
 All research institutions in Germany do have a \textbf{central IT Unit} of one form or another.
 At the very least, these are the persons that deal with the every-day IT-need of the institution:
 Internet access, Email, Web, central administration of computers (at least that of administrative staff), etc.
-Typically, the assigned tasks of the IT Unit are not research-driven, or also the staff does not have a research background.
-However, research software often has to work within the environment provided by the central IT Unit.
+Typically, the assigned tasks of the IT unit are not research-driven, or also the staff does not have a research background.
+However, research software often has to work within the environment provided by the central IT unit.
 A central RSE unit can help to either adapt the research software or even the environment such that the needs of researchers can be met.
-It is not unusual that this requires a level of engagement and understanding of the underlying research concepts that the staff of the IT Unit cannot provide alone.
+It is not unusual that this requires a level of engagement and understanding of the underlying research concepts that the staff of the IT unit cannot provide alone.
 
 A second important partner is the local \textbf{library}, which has already gained tasks much beyond the preservation and organisation of publications on physical paper for quite some time.
 Besides digital forms of rather traditional publications, these more and more include digital data and recently also software publications, their discovery and citation.
@@ -403,7 +403,7 @@ Requests by researchers in that direction often touch both aspects, RSE and RDM\
 Thus, often a close collaboration between RSE and RDM groups helps everyone: both RSE and RDM groups by being able to offer a more comprehensive service than when working alone, as well as the researcher, who benefits from receiving this single coordinated service, instead of dealing with two independent entities.
 The question whether RSE and RDM should be located in two separate groups or should be combined in one common group is intentionally left open, as the answer depends on local, pre-existing circumstances.
 
-Some research institutions might host a dedicated \textbf{HPC group}, maybe even independent of the computing centre.
+Some research institutions might host a dedicated \textbf{HPC group}, maybe even independent of the central IT unit.
 HPC is an RSE-related field, so HPC groups might already provide training, consulting and funding opportunities in this area.
 At the same time, HPC by nature focuses on highly efficient, many-core, if possible parallel computations.
 The challenges of an average researchers often start a long way before reaching that level, and they never might need to.
@@ -412,10 +412,10 @@ There are obvious reasons to closely collaborate on both consulting and training
 \subsection{Module 6: RSE Infrastructure Provisioning}%
 \label{sec:infrastructure}
 
-IT and (potentially high-performance) computing infrastructure provisioning is usually the purview of an institution's IT department and/or a computing centre.
+IT and (potentially high-performance) computing infrastructure provisioning is usually the purview of an institution's IT unit.
 However, a central RSE unit can provide extra services by acting as an intermediary for RSE infrastructure and by hosting pilot instances of new tools and services.
 IT departments typically only provide the service for hosting and accessing IT infrastructures, such as RSE infrastructures.
-Central RSE units are a link between the central services offered either by IT departments, computing centres or over-archlingly available services on one side,
+Central RSE units are a link between the central services offered either by IT units or over-archlingly available services on one side,
 and RSEs in spokes on the other, offering documentation, training and best-practices to efficiently and effectively use available services and comply with established processes.
 
 Furthermore, the central RSE unit can offer consulting for RSEs in spokes to guide selection processes of the tools and services best suited for each project.
@@ -426,9 +426,9 @@ This evaluation will specifically consider a wider applicability of the tool, wi
 
 It is crucial that the RSE unit does not compete with the IT department, nor should it duplicate existing infrastructure.
 On the contrary, the RSE unit should act as a multiplier for the RSE-relevant services offered by the IT department, helping RSEs to discover and use existing and upcoming services.
-Similarly, the RSE unit can promote the use of the available computing infrastructure provided by a computing centre, helping with the support of the users when RSE-related questions in this context arise.
-Once the mutual collaboration between RSE unit, IT department and computing centre has been established, a stricter policy-based involvement of the RSE unit for infrastructure requests is envisioned.
-Overall, by acting as an intermediary for RSE infrastructure related requests, the central RSE unit can augment the IT department and the computing centre, providing RSEs in spokes with the specific support they require.
+Similarly, the RSE unit can promote the use of the available computing infrastructure provided by an IT unit, helping with the support of the users when RSE-related questions in this context arise.
+Once the mutual collaboration between an RSE unit and an IT unit has been established, a stricter policy-based involvement of the RSE unit for infrastructure requests is envisioned.
+Overall, by acting as an intermediary for RSE infrastructure related requests, the central RSE unit can augment the central IT unit, providing RSEs in spokes with the specific support they require.
 
 \subsection{Module 7: Research Software Engineering Research}%
 \label{sec:rseresearch}
@@ -582,7 +582,7 @@ Such a concept should specify the idea of the RSE unit, its responsibilities and
 
 A rather difficult and crucial question can be the localisation of the RSE unit within the organisational structure of the institution.
 A canonical place would be a new subunit of an institutional body close to software,
-training services and computing such as the institution's IT department, the computing centre or the library.
+training services and computing such as the institution's IT unit, the IT unit or the library.
 Since most institutions already have an RDM unit, it seems natural to add the RSE unit as a parallel structure.
 Another choice for the superordinate body, particularly at universities, is the faculty for computer science.
 Determining the best place may involve discussing with several stakeholders at the institution and can already be beneficial for creating a

--- a/paper.tex
+++ b/paper.tex
@@ -416,7 +416,7 @@ There are obvious reasons to closely collaborate on both consulting and training
 IT and (potentially high-performance) computing infrastructure provisioning is usually the purview of an institution's IT unit.
 However, a central RSE unit can provide extra services by acting as an intermediary for RSE infrastructure and by hosting pilot instances of new tools and services.
 IT departments typically only provide the service for hosting and accessing IT infrastructures, such as RSE infrastructures.
-Central RSE units are a link between the central services offered either by IT units or over-archlingly available services on one side,
+Central RSE units are a link between the central services offered either by IT units or over-archingly available services on one side,
 and RSEs in spokes on the other, offering documentation, training and best-practices to efficiently and effectively use available services and comply with established processes.
 
 Furthermore, the central RSE unit can offer consulting for RSEs in spokes to guide selection processes of the tools and services best suited for each project.


### PR DESCRIPTION
closes #83 

I have also clarified that the IT units provide both centralised hardware and the IT services that run on the hardware. Otherwise it is a search and replace job.