### PR TITLE
RSEs as teachers

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -372,6 +372,8 @@ the tasks remaining for a central RSE unit are to adapt the material to local re
 For more complex software development projects, a central RSE unit can offer individual training.
 In both cases the expert RSEs from the central RSE unit can pass on their knowledge precisely adapted to the concrete needs of those that they support.
 
+Finally, in organisations that educate RSEs, members of a central RSE unit may contribute to the curriculum for and teach on an RSE master course. 
+
 \subsection{Module 5: Create a Network of Institutional Partners}%
 \label{sec:partners}
 

--- a/paper.tex
+++ b/paper.tex
@@ -370,7 +370,7 @@ Since teaching material for foundational software development skills is freely a
 the tasks remaining for a central RSE unit are to adapt the material to local requirements as well as to organise and hold courses and workshops.
 
 For more complex software development projects, a central RSE unit can offer individual training.
-In both cases the expert RSEs from the central RSE unit can pass on their knowledge precisely adapted to the concrete needs of those that they support.\todo{magi: what about teaching on regular courses?}
+In both cases the expert RSEs from the central RSE unit can pass on their knowledge precisely adapted to the concrete needs of those that they support.
 
 \subsection{Module 5: Create a Network of Institutional Partners}%
 \label{sec:partners}


### PR DESCRIPTION
closes #88 

I was tempted to just drop this TODO as it is probably more to do with embedded RSEs. It then occurred to me that central RSE units might well teach on RSE master courses if an organisation provides those.

I dunno, maybe we are too specific and overthinking. We could just accept the possibility that RSEs teach on courses (either domain specific or RSE).

What do you think?