### PR TITLE
Make boxes around success stories

### DIFF
--- a/.github/workflows/paper.yml
+++ b/.github/workflows/paper.yml
@@ -21,7 +21,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Install LaTeX requirements for matplotlib
-        run: sudo apt install -y texlive-latex-base texlive-latex-extra cm-super-minimal texlive-fonts-extra latexmk texlive-bibtex-extra 
+        run: sudo apt install -y texlive-latex-base texlive-latex-extra cm-super-minimal texlive-fonts-extra latexmk texlive-bibtex-extra biber
 
       - name: Create contributor snippet
         run: python contributors.py

--- a/.github/workflows/paper.yml
+++ b/.github/workflows/paper.yml
@@ -21,7 +21,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Install LaTeX requirements for matplotlib
-        run: sudo apt install -y texlive-latex-base texlive-latex-extra cm-super-minimal texlive-fonts-extra
+        run: sudo apt install -y texlive-latex-base texlive-latex-extra cm-super-minimal texlive-fonts-extra latexmk texlive-bibtex-extra 
 
       - name: Create contributor snippet
         run: python contributors.py
@@ -29,9 +29,8 @@ jobs:
       - name: Create group composition plot
         run: cd group_composition_plot && ./create_paper_plots.sh && cd -
       
-      - uses: xu-cheng/latex-action@v3
-        with:
-          root_file: paper.tex
+      - name: Compile paper
+        run: latexmk -pdf paper.tex
 
       - name: move
         run: mkdir -p github_artifacts && mv ${{ env.DIR }}/*.pdf ./github_artifacts/ 

--- a/.github/workflows/paper.yml
+++ b/.github/workflows/paper.yml
@@ -30,7 +30,7 @@ jobs:
         run: cd group_composition_plot && ./create_paper_plots.sh && cd -
       
       - name: Compile paper
-        run: latexmk -pdf paper.tex
+        run: latexmk -pdf --file-line-error --halt-on-error --interaction=nonstopmode --recorder paper.tex
 
       - name: move
         run: mkdir -p github_artifacts && mv ${{ env.DIR }}/*.pdf ./github_artifacts/ 

--- a/paper.tex
+++ b/paper.tex
@@ -8,6 +8,7 @@
 \DeclareUnicodeCharacter{200B}{{\hskip 0pt}}
 
 \usepackage{libertine}
+\usepackage[]{mdframed}
 \usepackage{orcidlink}
 \usepackage{rorlink}
 \renewcommand\Affilfont{\small}
@@ -346,23 +347,26 @@ Examples of topics that would benefit from such expertise pooling are \eg{} mobi
 RSE units that offer development services at all scales have proven to be a success story at many research institutions and have rapidly grown in size due to the influx of third party funding.
 Notable examples \autocite{Katz2019} are \eg{} Manchester~\autocite{Sinclair2022}, Notre-Dame \autocite{NotreDame2025}, Stanford~\autocite{Stanford2025}, Princeton~\autocite{Princeton2025, Cosden2022a}.
 
-[SuccessStory]
+\begin{mdframed}
 Founded in January 2017, the Research Computing department of Princeton University has experienced a tremendous growth from the initial two FTEs to a total of 18 FTEs in the span of five years~\autocite{Cosden2022a}.
 This growth is based on a continuous influx of new funded projects once successful projects showcase the additional value of RSE services to researchers.
+\end{mdframed}
 
-[Success Story]
+\begin{mdframed}
 The University of Manchester Software and Data Science group has successfully established specialised development services within their institution:
 The “Mobile Development Service” \autocite{manchester_mobile} team consists of RSEs that focus solely on developing and deploying mobile apps.
 Without a central RSE unit to anchor such specialised expertise, it would be difficult to establish such a service.
 Also, having this expertise centralised allows for synergies in the deployment procedure for mobile apps:
 The RSE unit can create institutional accounts with the app stores and manage the time consuming deployment process including hard-to-setup procedures like code signing.
 Besides the technical benefits of this central deployment procedure, the institution will also benefit from the increased visibility and potentially be able to build a brand with its technological output.
+\end{mdframed}
 
-[Success Story]
+\begin{mdframed}
 The Scientific IT Services of ETH Zurich (SIS) started in 2013 with a handful of members and has (as of March 2024) around 50 members.
 In addition to HPC services, the group also offers RSE services in various areas.
 These include the development of software applications for RDM, support in the development and improvement of scientific software or the long-term maintenance of software developed in research groups.
 In addition, SIS offers services in the areas of data science, machine learning, bioinformatics, trusted compute environments, and training and consulting.
+\end{mdframed}
 
 \subsection{Module 4: Teaching Services}%
 \label{sec:teaching}

--- a/paper.tex
+++ b/paper.tex
@@ -17,6 +17,8 @@
 \usepackage{xspace}
 \usepackage{caption,tikzpagenodes,everypage,ifthen}
 
+\usepackage{mdframed}
+
 \newcommand*{\eg}{e.\,g.\@\xspace}
 \newcommand*{\ie}{i.\,e.\@\xspace}
 

--- a/paper.tex
+++ b/paper.tex
@@ -348,12 +348,12 @@ RSE units that offer development services at all scales have proven to be a succ
 Notable examples \autocite{Katz2019} are \eg{} Manchester~\autocite{Sinclair2022}, Notre-Dame \autocite{NotreDame2025}, Stanford~\autocite{Stanford2025}, Princeton~\autocite{Princeton2025, Cosden2022a}.
 
 \begin{mdframed}
-Founded in January 2017, the Research Computing department of Princeton University has experienced a tremendous growth from the initial two FTEs to a total of 18 FTEs in the span of five years~\autocite{Cosden2022a}.
+\textbf{Success Story:} Founded in January 2017, the Research Computing department of Princeton University has experienced a tremendous growth from the initial two FTEs to a total of 18 FTEs in the span of five years~\autocite{Cosden2022a}.
 This growth is based on a continuous influx of new funded projects once successful projects showcase the additional value of RSE services to researchers.
 \end{mdframed}
 
 \begin{mdframed}
-The University of Manchester Software and Data Science group has successfully established specialised development services within their institution:
+\textbf{Success Story:} The University of Manchester Software and Data Science group has successfully established specialised development services within their institution:
 The “Mobile Development Service” \autocite{manchester_mobile} team consists of RSEs that focus solely on developing and deploying mobile apps.
 Without a central RSE unit to anchor such specialised expertise, it would be difficult to establish such a service.
 Also, having this expertise centralised allows for synergies in the deployment procedure for mobile apps:
@@ -362,7 +362,7 @@ Besides the technical benefits of this central deployment procedure, the institu
 \end{mdframed}
 
 \begin{mdframed}
-The Scientific IT Services of ETH Zurich (SIS) started in 2013 with a handful of members and has (as of March 2024) around 50 members.
+\textbf{Success Story:} The Scientific IT Services of ETH Zurich (SIS) started in 2013 with a handful of members and has (as of March 2024) around 50 members.
 In addition to HPC services, the group also offers RSE services in various areas.
 These include the development of software applications for RDM, support in the development and improvement of scientific software or the long-term maintenance of software developed in research groups.
 In addition, SIS offers services in the areas of data science, machine learning, bioinformatics, trusted compute environments, and training and consulting.

--- a/paper.tex
+++ b/paper.tex
@@ -348,24 +348,12 @@ RSE units that offer development services at all scales have proven to be a succ
 Notable examples \autocite{Katz2019} are \eg{} Manchester~\autocite{Sinclair2022}, Notre-Dame \autocite{NotreDame2025}, Stanford~\autocite{Stanford2025}, Princeton~\autocite{Princeton2025, Cosden2022a}.
 
 \begin{mdframed}
-\textbf{Success Story:} Founded in January 2017, the Research Computing department of Princeton University has experienced a tremendous growth from the initial two FTEs to a total of 18 FTEs in the span of five years~\autocite{Cosden2022a}.
-This growth is based on a continuous influx of new funded projects once successful projects showcase the additional value of RSE services to researchers.
-\end{mdframed}
-
-\begin{mdframed}
 \textbf{Success Story:} The University of Manchester Software and Data Science group has successfully established specialised development services within their institution:
 The “Mobile Development Service” \autocite{manchester_mobile} team consists of RSEs that focus solely on developing and deploying mobile apps.
 Without a central RSE unit to anchor such specialised expertise, it would be difficult to establish such a service.
 Also, having this expertise centralised allows for synergies in the deployment procedure for mobile apps:
 The RSE unit can create institutional accounts with the app stores and manage the time consuming deployment process including hard-to-setup procedures like code signing.
 Besides the technical benefits of this central deployment procedure, the institution will also benefit from the increased visibility and potentially be able to build a brand with its technological output.
-\end{mdframed}
-
-\begin{mdframed}
-\textbf{Success Story:} The Scientific IT Services of ETH Zurich (SIS) started in 2013 with a handful of members and has (as of March 2024) around 50 members.
-In addition to HPC services, the group also offers RSE services in various areas.
-These include the development of software applications for RDM, support in the development and improvement of scientific software or the long-term maintenance of software developed in research groups.
-In addition, SIS offers services in the areas of data science, machine learning, bioinformatics, trusted compute environments, and training and consulting.
 \end{mdframed}
 
 \subsection{Module 4: Teaching Services}%
@@ -639,11 +627,22 @@ The most promising possibilities to acquire further funding seem to be explicitl
 We believe that the credibility of a research proposal that is asking for RSE funds is greatly enhanced if the RSE unit is part of this proposal from the beginning.
 Over time, more and more researchers and proposals are expected to follow the institutional policy such that a consistent stream of income can be generated.
 
+\begin{mdframed}
+\textbf{Success Story:} Founded in January 2017, the Research Computing department of Princeton University has experienced a tremendous growth from the initial two FTEs to a total of 18 FTEs in the span of five years~\autocite{Cosden2022a}.
+This growth is based on a continuous influx of new funded projects once successful projects showcase the additional value of RSE services to researchers.
+\end{mdframed}
+
 \paragraph{Offering of additional services}
 With the additionally acquired funds, the service portfolio of the RSE unit can be enhanced regarding the modules described in \autoref{sec:vision}.
 Obviously, the selection of modules and their share in the overall portfolio depend on the services that have been applied for in the corresponding proposals.
 As this is strongly connected to hiring persons with the required expertise, this has to be carefully planned, see also below.
 
+\begin{mdframed}
+\textbf{Success Story:} The Scientific IT Services of ETH Zurich (SIS) started in 2013 with a handful of members and has (as of March 2024) around 50 members.
+In addition to HPC services, the group also offers RSE services in various areas.
+These include the development of software applications for RDM, support in the development and improvement of scientific software or the long-term maintenance of software developed in research groups.
+In addition, SIS offers services in the areas of data science, machine learning, bioinformatics, trusted compute environments, and training and consulting.
+\end{mdframed}
 
 \subsection{Outsourcing}
 


### PR DESCRIPTION
Following recommendation by @astruck in #64. We should discuss whether we want this, as all our success stories are lined up one after another and this might not necessarily have the visual effect that we originally intended. Another option would be to check where to move them. Only the Manchester story is really for Module 3.

This fixes #64.