### PR TITLE
Small fixes and some consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,6 +279,9 @@ TSWLatexianTemp*
 # TeXnicCenter
 *.tps
 
+# VS Code
+.vscode/
+
 # auto folder when using emacs and auctex
 ./auto/*
 *.el

--- a/paper.tex
+++ b/paper.tex
@@ -53,8 +53,8 @@
 This position paper urges decision makers in Germany to establish central RSE units within their institutions.
 Focus is not put primarily on the establishment of RSE services in general, as this has been done already elsewhere.
 Instead, we highlight central RSE units.
-Motivations for their existance are discussed, underpinned by working examples both in neighbouring fields as well as outside of Germany.
-The heart of this paper is a vision of a central RSE unit, it's structure, and the definition of nine core support modules such a unit may provide.
+Motivation for their existance is discussed, underpinned by working examples both in neighbouring fields as well as outside of Germany.
+The heart of this paper is a vision of a central RSE unit, its structure, and the definition of nine core support modules such a unit may provide.
 An initial survey finds that there is considerable diversity within the module distribution, even within the few considered groups.
 Initial observations on possible clusters are discussed, but need further studies.
 Finally, realisation strategies are discussed.
@@ -100,7 +100,7 @@ Another way to define the group of researchers are all people who at most very o
 This is our general term for the central RSE team throughout this paper.
 These RSE Hubs can take the form of, \eg{} full RSE units, smaller RSE groups, Open Source Program Offices (OSPOs), virtually across multiple units or combined under single leadership,
  depending on the environment of the hosting research organisation.
-All of these implementations are considered, taking into account the large variety of research environments in Germany which include not only universities, but also research consortia and other research performing organisations.
+All of these implementations are considered, taking into account the large variety of research environments in Germany, which include not only universities, but also research consortia and other research performing organisations.
 We use the term central \emph{RSE unit} interchangeably with the term \emph{RSE hub} even though for large federated research organisations there might be a more complex arrangement such as a network of RSE hubs.
 
 \section{Motivation for central RSE units}
@@ -108,7 +108,7 @@ We use the term central \emph{RSE unit} interchangeably with the term \emph{RSE 
       \textit{Better Software, Better Research}\\(Mission statement of the UK Software Sustainability Institute)
 \end{quotation}
 
-The quote above is the shortest possible summary of this chapter: most if not all motivation to provide RSE services stems from the goal of improving research.
+The quote above is the shortest possible summary of this chapter: Most if not all motivation to provide RSE services stems from the goal of improving research.
 Tasks RSEs perform include training, \eg{} to improve the quality of code produced by researchers~\autocite{Ostlund2023}, consultation services, \eg{} regarding frameworks or algorithm selection, and the development of existing or new software.
 For an overview of typical tasks of RSEs and the competencies required, see~\autocite{goth_foundational_competencies_2024}, especially section\ 4.4:\ “RSE tasks and responsibilities”.
 
@@ -120,7 +120,7 @@ First, pooling of \textbf{funding} allows organisations to invest in building up
 A central RSE team on long-term contracts will act as a knowledge hub due to their accumulated experience in and support of several disciplines as well as established contacts within the organisation.
 This is comparable to commercial/industry R\&D departments or so-called inhouse consulting~\autocite{Grima_2011}, where key software architects and developers establish a knowledge hub that can be consulted by project teams as necessary.
 Subject matter experts like software architects, database administrators and other tooling specialists are organised centrally and share their knowledge with members of decentralised projects.
-It makes economic sense to organise such staff centrally since not every project has a need for a full-time specialist or can afford one over an extended period of time.
+It makes economic sense to organise such staff centrally, since not every project has a need for a full-time specialist or can afford one over an extended period of time.
 Most academic research organisations have established centralised tooling, \eg{} storage or High-Performance-Computing\ (HPC), but only a few consider software development and consultancy a relevant service yet.
 
 A second and equally important aspect to pooling RSEs is that of \textbf{diverse knowledge}.
@@ -138,7 +138,7 @@ This allows members of that unit to bring in new ideas or transfer them from oth
 
 The third aspect to pooling RSEs is visible most of all from a users perspective: a \textbf{single, central contact point} for digital challenges is valuable to researchers, whose first problem often is not knowing whom to contact, partially because while they know what they want, they might not know what they need.
 A central RSE team can, due to its proximity to research, much better listen to the wishes expressed by researchers and then help formulate needs and act as a channel to either fulfil them themselves or reformulate and redirect the request.
-The results are increased research speed and quality and with that a higher reputation of the entire research organisation.
+The results are increased research speed and quality and, with that, a higher reputation of the entire research organisation.
 
 \subsection{Pooling: an already tested idea}
 The idea to pool resources in specific areas within an organisation is not new.
@@ -213,7 +213,7 @@ The rather complex assessment of FAIRness~\autocite{Wilkinson2023,FAIRmaturity} 
 \label{sec:vision}
 
 In this section, we describe our vision for central RSE units at research institutions in Germany.
-Institutions is, for our purposes, a broad term including universities, other colleges, associations like Max-Planck, Helmholtz, Fraunhofer, or Leibniz, as well as other research performing organisations.
+For our purposes, the term “institutions” is used broadly to include universities, other colleges, associations like Max-Planck, Helmholtz, Fraunhofer, or Leibniz, as well as other research-performing organisations.
 They show a wide variety in organisational structure as well as internal scientific diversity.
 Thus, there can be no single optimal blueprint for such an RSE unit for all research institutions in Germany.
 We instead describe modular components that can be mixed and matched based on the respective local environment.
@@ -256,7 +256,7 @@ Similarly an off-boarding process can help to make sure that all acquired knowle
 \label{sec:consultation}
 
 With the majority of researchers being self-taught programmers~\autocite{Carver2013}, there is a huge demand for expertise on how to develop better research software.
-Here, “better” can refer to a number of quality metrics such as correctness, reproducibility, maintainability, extendability, usability, portability, interoperability, performance or scalability~\autocite[Chapter 16]{Schulmeyer2008}.
+Here, “better” can refer to a number of quality metrics such as correctness, reproducibility, maintainability, extensibility, usability, portability, interoperability, performance or scalability~\autocite[Chapter 16]{Schulmeyer2008}.
 
 In order to raise the quality standards for research that is based on research software, it is of great importance for research institutions to provide access to such expertise with a low barrier to entry.
 The hub is a natural place to provide this central service.
@@ -296,14 +296,14 @@ This is especially relevant if the researchers hired for the research projects d
 Depending on the scale of the involvement, the RSE unit can either be included into the grant proposal via a co-PI or as an internal service provider.
 
 If the research within an institution heavily relies on specific pieces of software,
-it is of vital importance for the long term success of the institution to sustain these pieces of software.
+it is of vital importance for the long-term success of the institution to sustain these pieces of software.
 Relying on a workforce that is subject to academic labour turnover poses a risk of knowledge loss.
-If the development is done in an RSE unit with long-term contracts, institutional memory about critical research software infrastructures can be created and the long term availability of these infrastructures can be improved.
+If the development is done in an RSE unit with long-term contracts, institutional memory about critical research software infrastructures can be created and the long-term availability of these infrastructures can be improved.
 This applies both to domain-specific research software (\eg{} simulation frameworks widely used throughout the institution)
 and to domain-agnostic software and data infrastructure (\eg{} Jupyter, workflow management systems, data repository software).
 
 While all of the above development services can be flexibly performed either at the central RSE unit or by embedded RSEs, there are advantages of having a hub in the process:
-It allows building up highly specialised technical expertise with a long term perspective and reuse it across the entire institution.
+It allows building up highly specialised technical expertise with a long-term perspective and reuse it across the entire institution.
 Examples of topics that would benefit from such expertise pooling are \eg{} mobile app development and UI/UX development.
 
 RSE units that offer development services at all scales have proven to be a success story at many research institutions and have rapidly grown in size due to the influx of third party funding.
@@ -314,7 +314,7 @@ Notable examples~\autocite{Katz2019} are \eg{} Manchester~\autocite{Sinclair2022
 The “Mobile Development Service” \autocite{manchester_mobile} team consists of RSEs that focus solely on developing and deploying mobile apps.
 Without a central RSE unit to anchor such specialised expertise, it would be difficult to establish such a service.
 Also, having this expertise centralised allows for synergies in the deployment procedure for mobile apps:
-The RSE unit can create institutional accounts with the app stores and manage the time consuming deployment process including hard-to-setup procedures like code signing.
+The RSE unit can create institutional accounts with the app stores and manage the time-consuming deployment process including hard-to-setup procedures like code signing.
 Besides the technical benefits of this central deployment procedure, the institution will also benefit from the increased visibility and potentially be able to build a brand with its technological output.
 \end{mdframed}
 
@@ -404,10 +404,10 @@ For research software, dedicated archiving solutions such as Software Heritage~\
 In contrast to research data, however, the long-term availability and usability of research software requires more than an adequate archiving method:
 Software maintenance is an ongoing change process of software after its release.
 It includes  both fixing bugs that are discovered in the software and adapting the software to changes in the execution environment such as hardware, operating system, toolchain and software dependencies.
-In the scientific community there is a demand for long term maintenance of research software,
+In the scientific community there is a demand for long-term maintenance of research software,
  but academic labour turnover and missing funding schemes make research software maintenance often rely on the (potentially unpaid) efforts of individuals.
 
-An RSE hub with long term core staff can partially solve this problem by taking over maintenance tasks.
+An RSE hub with long-term core staff can partially solve this problem by taking over maintenance tasks.
 In order for this to be feasible two criteria need to be met:
 \begin{itemize}
 \item The software needs to be developed according to software engineering best practices with a strong emphasis on testing and continuous integration.
@@ -542,7 +542,7 @@ network of institutional partners, see the module described in \autoref{sec:part
 The business plan also needs to address funding for the RSE unit's initial staff.
 We consider it necessary that there is a certain amount of base funding provided by the institution that covers a basic RSE unit because much RSE work is not project based.
 While options can be drawn from the discussion above, specific ideas should be discussed beforehand with the decision makers.
-In order to facilitate long term growth of the RSE unit, an institutional policy for requesting person-months in externally funded projects dedicated to RSE should be established.
+In order to facilitate long-term growth of the RSE unit, an institutional policy for requesting person-months in externally funded projects dedicated to RSE should be established.
 
 Another part of the business plan should be the governance structure of the RSE unit.
 One of the decisions to be made is if the unit head is supposed to be part of the unit itself or if the unit will be headed by somebody outside of it.
@@ -557,9 +557,9 @@ Among other things, they are also responsible for organising meetings, developin
 The second position is a central RSE, responsible for providing selected services and infrastructure.
 These central positions complement the network of RSEs as described in~\autoref{sec:network}.
 
-Drawing from the business plan and considering the actual initial staff situation, a first task of the centrally funded structure is to define a basic service portfolio according to the modules described in \autoref{sec:vision}.
+Drawing from the business plan and considering the actual initial staff situation, a first task of the centrally-funded structure is to define a basic service portfolio according to the modules described in \autoref{sec:vision}.
 In addition to the already mentioned networking and teaching, see~\autoref{sec:network} and \autoref{sec:teaching}, it seems natural to start with consultation, see~\autoref{sec:consultation},
-as this allows to evaluate the potential necessities for other services such as development, infrastructure provisioning and maintenance.
+as this allows to evaluate the potential necessities for other services such as development, infrastructure provisioning, and maintenance.
 An extension of the initial service portfolio for a larger target audience requires the acquisition of funding for further positions, see below.
 
 The best RSE unit can easily become useless if other departments as well as RSEs outside the central hub do not know about it.
@@ -595,13 +595,13 @@ In addition, SIS offers services in the areas of data science, machine learning,
 \subsection{Outsourcing}
 
 Another possibility for the realisation of local RSE Service providers is by forming a spin-off and pooling the RSE Skills into an external company, which has benefits but also drawbacks.
-This is an idea, that so far lacks examples but for completeness we list some of the advantages and disadvantages.
+This is an idea that so far lacks examples but for completeness we list some of the advantages and disadvantages.
 Among the most obvious benefits is that this enables the creation of contracts outside of the WissZeitVG.\@
 This also widens the customer base of the RSE unit since the newly founded company may obtain contracts from industry.
 If this company is backed/branded by the institution, this enables another possibility for an institution to interact with local companies.
 This might open opportunities for employees to more freely move between industries and academia.
 But there are drawbacks.
-Since the company is now an entity external to the institution, the Vergabe-Richtlinien have to be fulfilled, which could \eg{} mean to publicly invite tenders in order to have a competitive procedure.
+Since the company is now an entity external to the institution, the Vergaberichtlinien have to be fulfilled, which could \eg{} mean to publicly invite tenders in order to have a competitive procedure.
 A company has to be profitable entity but this could be partly softened by founding a not-for-profit entity.
 Moreover, during the outsourcing contract, there has to be a coordinator at both sides and the flow of information from the academic institution to the contracted company has to be established.
 These are some examples of additional administrative overhead due to the interaction with external partners, and
@@ -615,7 +615,7 @@ On top of these drawbacks, there are soft factors, like whether an external comp
 RSE units need to be staffed, but where do potential employees come from?
 So far, researchers accidentally find themselves in the role of an RSE because they pursued software development as part of their research.
 A more deliberate approach with specific RSE education may be necessary to train people in sufficient numbers for central RSE units.
-Being an RSE should be a career worth aspiring to, just as any other profession, with a long term perspective.
+Being an RSE should be a career worth aspiring to, just as any other profession, with a long-term perspective.
 This is a topic covered by a separate paper~\autocite{goth_foundational_competencies_2024}, but we provide a brief summary here:
 
 These RSEs will bring a diverse set of skills centred around the topics of research,

--- a/paper.tex
+++ b/paper.tex
@@ -22,8 +22,8 @@
 
 \usepackage{mdframed}
 
-\newcommand*{\eg}{e.\,g.\@\xspace}
-\newcommand*{\ie}{i.\,e.\@\xspace}
+\newcommand*{\eg}{e.\,g.,\xspace}
+\newcommand*{\ie}{i.\,e.,\xspace}
 
 \hypersetup{%
   %pdftitle={},
@@ -94,7 +94,7 @@ However, we also recognise RSEs who have chosen to focus on a technical role as 
 We call RSEs who are members of the RSE hub (see below) dedicated RSEs.
 RSEs who are members of a research group are called embedded RSEs.
 RSEs might also be researchers.
-However, for the lack of a proper term and to avoid many “non-RSE researchers” within the text, we will use the term “researchers” to refer to all non-RSEs involved in research or in research supporting organisations such as in \eg{} libraries.
+However, for the lack of a proper term and to avoid many “non-RSE researchers” within the text, we will use the term “researchers” to refer to all non-RSEs involved in research or in research supporting organisations such as in, \eg{} libraries.
 Another way to define the group of researchers are all people who at most very ocassionaly perform RSE actions.
 \paragraph{RSE Hub}
 This is our general term for the central RSE team throughout this paper.
@@ -262,7 +262,7 @@ In order to raise the quality standards for research that is based on research s
 The hub is a natural place to provide this central service.
 There are a number of scenarios where RSE consultation services differ strongly in scale and format.
 We mention a few of these in the following.
-“Walk-in” consultations on any research software related aspect that are open to researchers of all career levels are a great introduction to the hub's RSE services and are offered by almost all RSE units already established (see e.g.\ data in Section~\ref{sec:existing} or~\cite{Katz2019}).
+“Walk-in” consultations on any research software related aspect that are open to researchers of all career levels are a great introduction to the hub's RSE services and are offered by almost all RSE units already established (see, \eg{} data in Section~\ref{sec:existing} or~\cite{Katz2019}).
 
 A larger scale format for RSE consultation services could be that a research project regularly meets with an RSE in order to coordinate the research software efforts done in the research project.
 This format enables valuable feedback cycles between researchers and RSEs and allows RSEs to guide the project
@@ -304,10 +304,10 @@ and to domain-agnostic software and data infrastructure (\eg{} Jupyter, workflow
 
 While all of the above development services can be flexibly performed either at the central RSE unit or by embedded RSEs, there are advantages of having a hub in the process:
 It allows building up highly specialised technical expertise with a long-term perspective and reuse it across the entire institution.
-Examples of topics that would benefit from such expertise pooling are \eg{} mobile app development and UI/UX development.
+Examples of topics that would benefit from such expertise pooling are, \eg{} mobile app development and UI/UX development.
 
 RSE units that offer development services at all scales have proven to be a success story at many research institutions and have rapidly grown in size due to the influx of third party funding.
-Notable examples~\autocite{Katz2019} are \eg{} Manchester~\autocite{Sinclair2022}, Notre-Dame~\autocite{NotreDame2025}, Stanford~\autocite{Stanford2025}, Princeton~\autocite{Princeton2025, Cosden2022a}.
+Notable examples~\autocite{Katz2019} are, \eg{} Manchester~\autocite{Sinclair2022}, Notre-Dame~\autocite{NotreDame2025}, Stanford~\autocite{Stanford2025}, Princeton~\autocite{Princeton2025, Cosden2022a}.
 
 \begin{mdframed}
 \textbf{Success Story:} The University of Manchester Software and Data Science group has successfully established specialised development services within their institution:
@@ -425,7 +425,7 @@ Regarding category (ii), the connection to other entities within the institution
 The RSE unit should advocate the use of RSE techniques and best practices within their institutions actively to strengthen the local community and to reach out to new groups whenever possible.
 One possible additional measure in this regard is sharing the work done by the RSE unit and the network RSEs as part of, for instance, institutional research colloquia.
 
-Activities in category (iii), i.e., outreach to RSE initiatives outside the institution include contributing to events, position papers and the initiatives themselves, either directly from the RSE unit or by advertising at the institution and matchmaking with local RSEs interested in becoming active beyond their local tasks.
+Activities in category (iii), \ie{} outreach to RSE initiatives outside the institution include contributing to events, position papers and the initiatives themselves, either directly from the RSE unit or by advertising at the institution and matchmaking with local RSEs interested in becoming active beyond their local tasks.
 The RSE unit thus contributes to the RSE communities on a regional, national or international level on the one hand and opens these up to the local RSEs and enables networking on the other hand.
 It organises the bidirectional exchange between the local and the global community and is the central hub for information coming both ways.
 
@@ -459,7 +459,7 @@ This depends on the demand by scientists at the institution, existing structures
 
 We propose building blocks for individual realisation strategies for central institutional RSE units.
 We start by listing different possibilities for funding RSE positions at a research institution.
-Following that, we describe a potential transition pathway, starting from existing structures that have grown in research alliances such as \eg{} DFG-funded Collaborative Research Centres or also in research departments of an institution.
+Following that, we describe a potential transition pathway, starting from existing structures that have grown in research alliances such as, \eg{} DFG-funded Collaborative Research Centres or also in research departments of an institution.
 This is complemented by discussions of the possibility of outsourcing RSE services and of the challenging task of identifying and hiring suitable RSE candidates.
 
 \subsection{Funding Possibilities}%
@@ -601,7 +601,7 @@ This also widens the customer base of the RSE unit since the newly founded compa
 If this company is backed/branded by the institution, this enables another possibility for an institution to interact with local companies.
 This might open opportunities for employees to more freely move between industries and academia.
 But there are drawbacks.
-Since the company is now an entity external to the institution, the Vergaberichtlinien have to be fulfilled, which could \eg{} mean to publicly invite tenders in order to have a competitive procedure.
+Since the company is now an entity external to the institution, the Vergaberichtlinien have to be fulfilled, which could, \eg{} mean to publicly invite tenders in order to have a competitive procedure.
 A company has to be profitable entity but this could be partly softened by founding a not-for-profit entity.
 Moreover, during the outsourcing contract, there has to be a coordinator at both sides and the flow of information from the academic institution to the contracted company has to be established.
 These are some examples of additional administrative overhead due to the interaction with external partners, and

--- a/paper.tex
+++ b/paper.tex
@@ -606,7 +606,7 @@ This also widens the customer base of the RSE unit since the newly founded compa
 If this company is backed/branded by the institution, this enables another possibility for an institution to interact with local companies.
 This might open opportunities for employees to more freely move between industries and academia.
 But there are drawbacks.
-Since the company is now an entity external to the institution, the Vergaberichtlinien have to be fulfilled, which could, \eg{} mean to publicly invite tenders in order to have a competitive procedure.
+Since the company is now an entity external to the institution, the procurement guidelines (“Vergaberichtlinien”) have to be fulfilled, which could, \eg{} mean to publicly invite tenders in order to have a competitive procedure.
 A company has to be profitable entity but this could be partly softened by founding a not-for-profit entity.
 Moreover, during the outsourcing contract, there has to be a coordinator at both sides and the flow of information from the academic institution to the contracted company has to be established.
 These are some examples of additional administrative overhead due to the interaction with external partners, and


### PR DESCRIPTION
This PR corrects some minor typos and tries to fix some awkward-sounding language.

In addition, it makes the use of commas before and after "e.g." consistent throughout the paper.

While the first change is IMHO an objective improvement, the second one is prone to bike-shedding, thus the separation into two commits.