### PR TITLE
Partially revert previously introduced title change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# de-RSE Community paper on "Establishing RSE departments in German research institutions"
+# de-RSE Community paper on "Establishing Research Software Engineering departments in German research institutions"
 
 This repository hosts the draft for a community paper by the de-RSE e.V. community.
 

--- a/paper.tex
+++ b/paper.tex
@@ -39,7 +39,7 @@
 \addbibresource{positionpaper.bib}
 \setcounter{biburllcpenalty}{100}
 
-\title{Developing central Research Software Engineering units in German research institutions}
+\title{Establishing central Research Software Engineering units in German research institutions}
 
 \input{contributors.tex}
 


### PR DESCRIPTION
#132 introduced a change of the title, which went unnoticed from my side. While I agree with spelling out RSE, I would like to keep the "Establishing..." compared to "Developing...". Additionally, the paper passed community review under that title, so we should not change it after review.