### PR TITLE
Justify the €50M third-party funding figure

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -505,7 +505,7 @@ An institution’s leadership has to justify taking the corresponding risk of fa
       Depending on the local circumstances at an institution, this can be a cumbersome and time-consuming process for each such position.
 \item Funding organisations additionally allocate a portion of the direct project funds as overhead, which is typically divided between the institution and the applicant.
       We propose using a small percentage of the overhead agglomerated at the institution to permanently finance central RSE positions.
-      Assuming a third-party funding income of €50 million annually and a 20\% overhead, €100,000 in permanent funding requirements for one person-year would only account for 1\% of this overhead.
+      Assuming a third-party funding income of €50 million\footnote{While the spread in third-party funding over German research institutions is very large, we consider €50 million as a representative value. For example, the (technical) universities of Hamburg, Siegen, Wuppertal, Cottbus-Senftenberg, Oldenburg and Bayreuth list within €45 and €55 million of third-party revenues in 2022, see https://foerderatlas.dfg.de/daten/drittmitteleinnahmen-2022-nach-hochschulen-und-fachgebieten-in-mio-e/.} annually and a 20\% overhead, €100,000 in permanent funding requirements for one person-year would only account for 1\% of this overhead.
 \item In project applications involving the development of research software, corresponding person-months should be requested to finance RSE tasks.
       In this way, an applicant can book a fixed number of working hours from the RSE pool and pay for the costs accordingly.
       This model has been successfully implemented at several UK universities.

--- a/review_answers/review_2_answers.md
+++ b/review_answers/review_2_answers.md
@@ -148,6 +148,7 @@
 > Section 5.1 lists four funding sources. Source 2 (overhead percentage) proposes using 1% of overhead. Where does this 1% figure come from? Provide a justification or remove the specific number.
 
 **Answer:**
+It is evident that this is an exemplary statement and that the 1% is the outcome of the requirement to get funding for one person-year assuming 50 MEUR third-party revenue. So the question should rather be where the 50 MEUR come from. We added a corresponding footnote.
 
 ---
 


### PR DESCRIPTION
Closes #181

Adds a footnote to justify the €50 million annual third-party funding figure.