### PR TITLE
Add answer to comment on RSE master programmes

### DIFF
--- a/review_answers/review_2_answers.md
+++ b/review_answers/review_2_answers.md
@@ -169,6 +169,7 @@
 > Section 5.4 on "Staff acquisition" mentions "RSE master" programs in Berlin, Munich, and Stuttgart. You cite a curated list (reference 60) but do not say whether any graduates from these programs have been hired into central RSE units. Add this if known.
 
 **Answer:**
+We do not have any specific numbers at this point in time.
 
 ---
 


### PR DESCRIPTION
Fixes #184

Adds an answer to Reviewer 2's comment on Section 5.4 ("Staff acquisition"), which asks whether any graduates from RSE master programmes in Berlin, Munich, and Stuttgart have been hired into central RSE units.