### PR TITLE
Answer comment on unsupported claims in the conclusion

### DIFF
--- a/review_answers/review_2_answers.md
+++ b/review_answers/review_2_answers.md
@@ -178,6 +178,7 @@
 > The conclusions repeat claims about "improved funding acquisition" and "enhanced reputational standing" that were not strongly supported earlier. Remove these claims or add direct evidence.
 
 **Answer:**
+Please see our general answer on this manuscript being an _opinion article._
 
 ---
 


### PR DESCRIPTION
Fixes #185

Adds an answer to Reviewer 2's comment on the Conclusions section, which asks to remove or back up claims about "improved funding acquisition" and "enhanced reputational standing."